### PR TITLE
fixed bug in safe_extract to return NULL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: labradoR
 Title: Read and Process Retriever's Output
-Version: 1.1.2
+Version: 1.1.3
 Authors@R: 
     person("Renzo", "Bonifazi", , "renzo.bonifazi@outlook.it", role = c("aut", "cre"),
            comment = c(ORCID = "https://orcid.org/0000-0002-1794-4708"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # labradoR
 
+## Version 1.1.3
+### Bug fixes
+- fixed `safe_extract.R` to not return `NULL` but results when a warning or message is detected.
+
 ## Version 1.1.2
 
 ### Bug fixes

--- a/R/extract_text.R
+++ b/R/extract_text.R
@@ -32,7 +32,7 @@ extract_text <- function(content_lines, keyword) {
   } else if (length(matches) > 1) {
     keyword_line <- matches[1]
     warning(
-      paste0("Keyword '", keyword, "' was found in multiple places. Only the first match is going to be used. \n Matched line numbers are:\n", matches),
+      paste0("Keyword '", keyword, "' was found in multiple places. Only the first match is going to be used. \n Matched line numbers are:\n"),
       paste0(matches, sep = " ")
     )
   # if keyword is not found, return what info we are looking for that are not matched

--- a/man/safe_extract.Rd
+++ b/man/safe_extract.Rd
@@ -14,7 +14,8 @@ safe_extract(function_to_exec, ..., return_error = TRUE)
 \item{return_error}{Logical; if \code{TRUE}, errors and warnings are logged in \code{error_log}.}
 }
 \value{
-The result of \code{function_to_exec(...)} if successful, otherwise \code{NULL}.
+The result of \code{function_to_exec(...)} if successful, otherwise \code{NULL} if error is detected.
+If a warning or message is detected, the results of \code{function_to_exec()} are still returned.
 }
 \description{
 This function attempts to execute a given function and captures any errors


### PR DESCRIPTION
This pull request primarily focus on bug fixes and updates to the `safe_extract` function to improve its error handling capabilities.
Related issue: https://github.com/bonifazi/labradoR/issues/9
### Version Update:
* Updated the package version from 1.1.2 to 1.1.3 in the `DESCRIPTION` file.

### Bug Fixes:
* Fixed the `safe_extract.R` function to ensure it returns results even when a warning or message is detected, instead of returning `NULL`. This change is documented in the `NEWS.md` file.

### Error Handling Improvements:
* Modified the `safe_extract` function to use `withCallingHandlers` for capturing warnings and logging them without interrupting the function execution. This ensures that results are returned even if warnings occur. [[1]](diffhunk://#diff-45289d290dc1b1ac3a6a70c81dc9c8951e2b0960eb18b5f8099819af089da72cR27-R37) [[2]](diffhunk://#diff-45289d290dc1b1ac3a6a70c81dc9c8951e2b0960eb18b5f8099819af089da72cL37-R50)
* Updated the documentation in `safe_extract.R` and `man/safe_extract.Rd` to reflect the new behavior of returning results when warnings or messages are detected. [[1]](diffhunk://#diff-45289d290dc1b1ac3a6a70c81dc9c8951e2b0960eb18b5f8099819af089da72cL11-R12) [[2]](diffhunk://#diff-ec9885ceb03d90778e0359e8af3a3132421971188c1d24defa3bac53ef486193L17-R18)

### Minor Changes:
* Removed redundant code in the `extract_text` function to clean up the warning message formatting.